### PR TITLE
JavaScript Quality of Life updates

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+/py/
+/ex/
+/build/
+/js/__tests__/
+.travis.yml
+MANIFEST.in
+mix.exs
+pytest.ini
+setup.cfg
+setup.py
+.gitattributes

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Erlpack
 
-Erlpack is a fast encoder and decoder for the Erlang Term Format (version 131) for Python and Javascript.
+Erlpack is a fast encoder and decoder for the Erlang Term Format (version 131) for Python and JavaScript.
 
-# Javascript
+# JavaScript
 
 ## Things that can be packed:
 
@@ -65,7 +65,7 @@ v8::Local<v8::Value> ConvertToNodeBuffer(const v8::Local<v8::Object>& blinkArray
 }
 ```
 
-Then in Javascript something like:
+Then in JavaScript something like:
 
 ```js
 let packed = NativeUtils.convertToNodeBuffer(new Uint8Array(binaryPayload));

--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'erlpack' {
+	export function pack(data: any): Buffer;
+	export function unpack(data: Buffer): any; 
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./js/index.js",
   "name": "erlpack",
   "version": "0.1.3",
-  "description": "Erlpack is a fast encoder and decoder for the Erlang Term Format (version 131) for Javascript",
+  "description": "Erlpack is a fast encoder and decoder for the Erlang Term Format (version 131) for JavaScript",
   "scripts": {
     "test": "jest"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "main": "./js/index.js",
+  "types": "./js/index.d.ts",
   "name": "erlpack",
   "version": "0.1.3",
   "description": "Erlpack is a fast encoder and decoder for the Erlang Term Format (version 131) for JavaScript",
@@ -14,6 +15,7 @@
   },
   "gypfile": true,
   "devDependencies": {
+    "@types/node": "^12.11.7",
     "jest-cli": "^24.9.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "author": "Jason Citron",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "dependencies": {
     "bindings": "^1.5.0",
     "nan": "^2.14.0"


### PR DESCRIPTION
This PR updates some things in the NPM/JavaScript part that have been wrong or missing for quite a while.

- Added an .npmignore that excludes some files that are not needed from being published to NPM (This can probably be extended with parts of the vendor folder in the future)
- Renamed "Javascript" to "JavaScript"
- Added typings for TypeScript
- Changed the license inside the package.json to MIT